### PR TITLE
Saving initial payment data in singleton

### DIFF
--- a/src/CreditCardForm/CreditCardForm.android.tsx
+++ b/src/CreditCardForm/CreditCardForm.android.tsx
@@ -12,8 +12,7 @@ class CreditCardForm {
   private static instance: CreditCardForm;
 
   private constructor(paymentData: PaymentData, jsonData?: PaymentJsonData) {
-    const jsonDataString = jsonData && JSON.stringify(jsonData);
-    CreditCardFormManager.initialPaymentData(paymentData, jsonDataString);
+    CreditCardForm.saveInitialPaymentData(paymentData, jsonData)
   }
 
   public static initialPaymentData(
@@ -23,7 +22,8 @@ class CreditCardForm {
     if (!CreditCardForm.instance) {
       CreditCardForm.instance = new CreditCardForm(paymentData, jsonData);
     }
-
+    // Saving passed initial data
+    CreditCardForm.saveInitialPaymentData(paymentData, jsonData)
     return CreditCardForm.instance;
   }
 
@@ -46,6 +46,11 @@ class CreditCardForm {
       });
     return transactionId;
   };
+
+  private static saveInitialPaymentData(paymentData: PaymentData, jsonData?: PaymentJsonData): void {
+    const jsonDataString = jsonData && JSON.stringify(jsonData);
+    CreditCardFormManager.initialPaymentData(paymentData, jsonDataString);
+  }
 }
 
 export default CreditCardForm;

--- a/src/CreditCardForm/CreditCardForm.ios.tsx
+++ b/src/CreditCardForm/CreditCardForm.ios.tsx
@@ -12,7 +12,7 @@ class CreditCardForm {
   private static instance: CreditCardForm;
 
   private constructor(paymentData: PaymentData, jsonData?: PaymentJsonData) {
-    CreditCardFormManager.initialPaymentData(paymentData, jsonData);
+    CreditCardForm.saveInitialPaymentData(paymentData, jsonData);
   }
 
   public static initialPaymentData(
@@ -22,7 +22,8 @@ class CreditCardForm {
     if (!CreditCardForm.instance) {
       CreditCardForm.instance = new CreditCardForm(paymentData, jsonData);
     }
-
+    // Saving passed initial data
+    CreditCardForm.saveInitialPaymentData(paymentData, jsonData);
     return CreditCardForm.instance;
   }
 
@@ -45,6 +46,10 @@ class CreditCardForm {
       });
     return transactionId;
   };
+  private static saveInitialPaymentData(paymentData: PaymentData, jsonData?: PaymentJsonData): void {
+    CreditCardFormManager.initialPaymentData(paymentData, jsonData);
+  }
+
 }
 
 export default CreditCardForm;


### PR DESCRIPTION
Ребята, большое спасибо за реализацию, мы сэкономили кучу времени.

Но у нас возникла проблема с передачей `invoiceId` в Cloudpayments.
Из-за того, что синглтон при последующих оплатах передавался один и тот же инвойс.
Я сделал пересохранение данных в инстансе.

Если ломает общую логику, можете отменить, но я подумал, что может быть полезно